### PR TITLE
Set default value " />" for MarkdownOptions.EmptyElementSuffix.

### DIFF
--- a/src/MarkdownSharp/Markdown.cs
+++ b/src/MarkdownSharp/Markdown.cs
@@ -111,7 +111,7 @@ namespace MarkdownSharp
         /// <summary>
         /// use ">" for HTML output, or " />" for XHTML output
         /// </summary>
-        public string EmptyElementSuffix { get; set; }
+        public string EmptyElementSuffix { get; set; } = " />";
 
         /// <summary>
         /// when false, email addresses will never be auto-linked  

--- a/tests/MarkdownSharp.Tests/ConfigTest.cs
+++ b/tests/MarkdownSharp.Tests/ConfigTest.cs
@@ -58,6 +58,19 @@ namespace MarkdownSharpTests
         }
 
         [Fact]
+        public void TestDefaultOptions()
+        {
+            var markdownWithoutOptions = new Markdown();
+            Assert.Equal(" />", markdownWithoutOptions.EmptyElementSuffix);
+
+            var markdownWithOptions = new Markdown(new MarkdownOptions { });
+            Assert.Equal(" />", markdownWithOptions.EmptyElementSuffix);
+
+            var options = new MarkdownOptions { };
+            Assert.Equal(" />", options.EmptyElementSuffix);
+        }
+
+        [Fact]
         public void TestEmptyElementSuffix()
         {
             var markdown = new Markdown();


### PR DESCRIPTION
## Problem
I met the problem like #9 when I wrote the code as follows.

```
var markdown = new Markdown(new MarkdownOptions { AutoNewlines = true });
var html = markdown.Transform("AB\nCD"); // Result: "<p>AB<br\nCD</p>" (Unexpected)
```

`"\n"` was converted to `"<br\n"`. It's not expected for me and everyone, I think.

We can fix this code like `var markdown = new Markdown(new MarkdownOptions { AutoNewlines = true, EmptyElementSuffix = " />" });`, but it's more useful if the default value of `MarkdownOptions .EmptyElementSuffix` was set.

## Solution
This PR sets default value `" />"` for `MarkdownOptions.EmptyElementSuffix`.
It's the same default value as `Markdown.EmptyElementSuffix`.
